### PR TITLE
PAY-7662 CVE-2024-45296

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "socks": "^2.8.3",
     "body-parser": "^1.20.3",
     "serve-static": "^1.16.2",
-    "path-to-regexp": "^0.2.0",
+    "path-to-regexp": "~1.9.0",
     "cross-spawn": "7.0.6",
     "cookie": "^0.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10585,10 +10585,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^0.2.0":
-  version: 0.2.5
-  resolution: "path-to-regexp@npm:0.2.5"
-  checksum: 44adcbd847d170786490de80d2abc4762d5e65cd8857f230b87bdff6ab1bd17a91baa201fea549954b4cbfd208ae021a3a4ebac19a69ebdf3fdc628c8344ad39
+"path-to-regexp@npm:~1.9.0":
+  version: 1.9.0
+  resolution: "path-to-regexp@npm:1.9.0"
+  dependencies:
+    isarray: 0.0.1
+  checksum: 5b2ac9cab2a9f82effd30a35164b20998b18d99d96608281dd2cab6e66c0e4536187970369b185ab21d3815da1ecb7dcb2d5f97a4bf0ee6e31a9612299fca147
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/PAY-7662


### Change description ###
changed the path-to-regexp version to ~1.9.0
Ran the code locally and produced a payment outcome.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
